### PR TITLE
Add Initial TSC members

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,3 +1,11 @@
+Initial TSC (Technical Steering Committee) Members:
+
+* Aaron Olson
+* Jonathan Pulsifer
+* Kyle Peatt
+
+Initial Contributors:
+
 * Aaron Olson
 * Adam Whitcroft
 * Alexandra Clark


### PR DESCRIPTION
As discussed in Zoom, this PR adds a section to indicate initial membership of the Technical Steering Committee (TSC) for the project.

cc @jonpulsifer @kpeatt 